### PR TITLE
OGPの修正その2

### DIFF
--- a/src/app/[facultyCategoryPathName]/opengraph-image.tsx
+++ b/src/app/[facultyCategoryPathName]/opengraph-image.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @next/next/no-img-element */
 import { getFacultyCategoryFromPathName } from '@/lib/facultyCategories';
 import { facultyCategoryLogoPath } from '@/lib/facultyCategoryLogo';
+import { FacultyCategoryPathName } from '@/types/FacultyCategory';
 import { readFile } from 'fs/promises';
 import { ImageResponse } from 'next/og';
 
-export default async function Image({ params }) {
+export default async function Image({ params }: { params: { facultyCategoryPathName: FacultyCategoryPathName } }) {
   const path = facultyCategoryLogoPath(
     getFacultyCategoryFromPathName(params.facultyCategoryPathName).name
   );
   const logoData = await readFile(path);
-  const logoSrc = Uint8Array.from(logoData).buffer;
+  const logoSrc: any = Uint8Array.from(logoData).buffer;
 
   return new ImageResponse(
     (

--- a/src/app/fortune/[facultyCategoryPathName]/opengraph-image.tsx
+++ b/src/app/fortune/[facultyCategoryPathName]/opengraph-image.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @next/next/no-img-element */
 import { getFacultyCategoryFromPathName } from '@/lib/facultyCategories';
 import { facultyCategoryLogoPath } from '@/lib/facultyCategoryLogo';
+import { FacultyCategoryPathName } from '@/types/FacultyCategory';
 import { readFile } from 'fs/promises';
 import { ImageResponse } from 'next/og';
 
-export default async function Image({ params }) {
+export default async function Image({ params }: { params: { facultyCategoryPathName: FacultyCategoryPathName } }) {
   const path = facultyCategoryLogoPath(
     getFacultyCategoryFromPathName(params.facultyCategoryPathName).name
   );
   const logoData = await readFile(path);
-  const logoSrc = Uint8Array.from(logoData).buffer;
+  const logoSrc: any = Uint8Array.from(logoData).buffer;
 
   return new ImageResponse(
     (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,13 +24,6 @@
     },
     "types": ["@testing-library/jest-dom"]
   },
-  "include": [
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "src/app/[facultyCategoryPathName]/opengraph-image.js",
-    "src/app/fortune/[facultyCategoryPathName]/opengraph-image.js"
-  ],
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
imgタグのsrc要素にArrayBufferLike型を代入しようとしたらコンパイルエラーになったので、anyで型注釈。
![image](https://github.com/user-attachments/assets/394efa37-9ea6-476a-9414-4d6fa760f849)

公式の通りにやっているはずなのだが…
https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#using-nodejs-runtime-with-local-assets


