### PR TITLE
top_logo.pngのwarningを消す

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,6 @@ export default function Page({
           src={logo}
           alt="秘境集落探索ツール"
           width={300}
-          height={300}
         />
       </h1>
       <p className="text-center my-4 leading-relaxed">


### PR DESCRIPTION
# 概要
こちらのレビュー指摘の修正。
> top_logo.png も何か画像アスペクト比の warn が出てそうなので直せると良さそう
![image](https://github.com/user-attachments/assets/417142ef-aa6d-4e84-b95c-00c7586e498b)

https://bootcamp.fjord.jp/products/20784#comment_175374

# やったこと
heightとwidthを両方指定していたことが原因。widthのみを指定するように修正。これでWarningが出なくなることを確認。

next.jsのImageは基本的にはwidthとheightは両方必須らしいが、今回はstatically imported imageに該当するので指定しなくても良いケースだと思われる。
https://nextjs.org/docs/app/api-reference/components/image#width

# 動作確認
修正前・修正後ともに幅が300pxの画像となっている
![image](https://github.com/user-attachments/assets/82b13f15-b548-4540-baef-a3280e775a0f)
