### PR TITLE
想定しないパスにアクセスされたときに404ページを表示する

### DIFF
--- a/src/app/[facultyCategoryPathName]/page.tsx
+++ b/src/app/[facultyCategoryPathName]/page.tsx
@@ -1,13 +1,17 @@
 import FacultyList from "@/components/FacultyList";
 import FacultySearchForm from "@/components/FacultySearchForm";
 import { getAreaByEnName } from "@/lib/areas";
-import { getFacultyCategoryFromPathName } from "@/lib/facultyCategories";
+import {
+  facultyCategoryPathNames,
+  getFacultyCategoryFromPathName,
+} from "@/lib/facultyCategories";
 import { facultyCategoryLogo } from "@/lib/facultyCategoryLogo";
 import { getIslandSettingByEnName } from "@/lib/islandSettings";
 import { FacultyCategoryPathName } from "@/types/FacultyCategory";
 import FacultySearchParams from "@/types/FacultySearchParams";
 import { Metadata } from "next";
 import Image from "next/image";
+import { notFound } from "next/navigation";
 
 type Props = {
   params: { facultyCategoryPathName: FacultyCategoryPathName };
@@ -15,6 +19,9 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  if (!facultyCategoryPathNames.includes(params.facultyCategoryPathName)) {
+    notFound();
+  }
   const facultyCategoryName = getFacultyCategoryFromPathName(
     params.facultyCategoryPathName,
   ).name;

--- a/src/app/fortune/[facultyCategoryPathName]/page.tsx
+++ b/src/app/fortune/[facultyCategoryPathName]/page.tsx
@@ -1,15 +1,22 @@
 import FacultyFortuneModal from "@/components/FacultyFortuneModal";
-import { getFacultyCategoryFromPathName } from "@/lib/facultyCategories";
+import {
+  facultyCategoryPathNames,
+  getFacultyCategoryFromPathName,
+} from "@/lib/facultyCategories";
 import { facultyCategoryLogo } from "@/lib/facultyCategoryLogo";
 import { FacultyCategoryPathName } from "@/types/FacultyCategory";
 import { Metadata } from "next";
 import Image from "next/image";
+import { notFound } from "next/navigation";
 
 type Props = {
   params: { facultyCategoryPathName: FacultyCategoryPathName };
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  if (!facultyCategoryPathNames.includes(params.facultyCategoryPathName)) {
+    notFound();
+  }
   const facultyCategoryName = getFacultyCategoryFromPathName(
     params.facultyCategoryPathName,
   ).name;


### PR DESCRIPTION
# 概要
こちらのレビューの対応。
https://bootcamp.fjord.jp/products/20784#comment_175374
> 例えば https://search-isolated-villages.com/hogehoge のようなアクセスがあったとき、意図してないページになっていそうです。
この辺りは Next.js 側でハンドリングできるはずなのでやっておくと良さそうです！

# やったこと
施設区分名（post_officeなど）を期待するパスに対してそうでない文字列でアクセスされた場合は、notFoundページを表示する。

# 動作確認
## 修正前
500エラーとなってしまう。
![image](https://github.com/user-attachments/assets/83f9f244-ce33-4335-b9b9-7fc503c7f4de)

## 修正後
404ページが出る。
![image](https://github.com/user-attachments/assets/78d393ba-fcc3-4d16-a2e2-f95928264a9b)

