### PR TITLE
brのクラスを分かりやすくする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,12 +26,8 @@ export default function Page({
           width={300}
         />
       </h1>
-      <p className="my-4 text-center leading-relaxed">
-        秘境集落を探索し、人口分布データを
-        <br className="sm:hidden" />
-        もとに秘境度を
-        <br className="hidden sm:block" />
-        評価して地域別に
+      <p className="mx-auto my-4 w-[280px] text-center leading-relaxed sm:w-[390px]">
+        秘境集落を探索し、人口分布データをもとに秘境度を評価して地域別に
         <br className="sm:hidden" />
         ランキングで出力します。
       </p>


### PR DESCRIPTION
こちらのレビュー対応。
https://bootcamp.fjord.jp/products/20784#comment_175374
> br のクラスがわかりずらいので、いっそ親要素の width を sm: などで切り替えてもいいかなと思いました！ w-[300px] のような arvitary value を使って良いと思います

1行目の改行は親クラスのwidthを調整することで対応できたが、2行目の改行を丁度良い箇所で行うためには、既存のbrクラスを使わざるをえなかった。
また、秘境施設探索ツールのページについては、施設名が動的に変化するため、そのままとしている。
https://github.com/ogawa-tomo/search-isolated-villages-2-front/blob/a8866d5d27c354b94a623fd06ae9dddabd76983e/src/app/%5BfacultyCategoryPathName%5D/page.tsx#L51-L57