### PR TITLE
JestとPlaywrightを並列で実行する

### DIFF
--- a/.github/workflows/component_test.yml
+++ b/.github/workflows/component_test.yml
@@ -1,11 +1,10 @@
-name: Run Test
+name: Component Test
 
 on: [push]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -14,8 +13,6 @@ jobs:
           node-version: "20.x"
           cache: "npm"
       - run: npm ci
+      - run: npm run typecheck
+      - run: npm run build
       - run: npm test
-      - run: docker compose up -d
-      - run: npx playwright install
-      - run: npx playwright install --with-deps
-      - run: npx playwright test

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,19 @@
+name: E2E Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+      - run: npm ci
+      - run: docker compose up -d
+      - run: npx playwright install
+      - run: npx playwright install --with-deps
+      - run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint:fix": "next lint --fix",
     "test": "jest",
     "format": "prettier --write .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "typecheck": "tsc"
   },
   "lint-staged": {
     "*.{ts,tsx}": "prettier --write"


### PR DESCRIPTION
こちらのレビュー対応
https://bootcamp.fjord.jp/products/20784#comment_175374
> CI でテストしているの良い
欲を言えば、unit test と e2e は. job を分けて並列で実行してあげた方が良さそうですね！（yml を分けるイメージ）
typecheck や build も入れて上げるとより安心かと！（lint は husky あるからいいかな）

jobは基本的に並列で実行されるが、分かりやすさのためymlファイルを分離した
https://docs.github.com/ja/actions/writing-workflows/about-workflows#creating-dependent-jobs
また、型チェックとビルドを加えている
