### PR TITLE
Herokuをスリープから起こすためにリクエストを投げるのをやめる

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,11 +11,6 @@ export default function Page({
 }: {
   searchParams: VillageSearchParams;
 }) {
-  // herokuのサーバーをスリープ状態から起こすためにリクエストを投げる
-  fetch(process.env.NEXT_PUBLIC_VILLAGE_API_URL ?? "", {
-    next: { revalidate: 3600 },
-  });
-
   return (
     <>
       <h1>


### PR DESCRIPTION
こちらのレビュー対応。
https://bootcamp.fjord.jp/products/20784#comment_175374
> https://github.com/ogawa-tomo/search-isolated-villages-2-front/blob/b12ae1f0eb6821565b22db9188525ab7d3511cdf/src/app/page.tsx#L15-L18
これの妥当性をもうちょい慎重に考えてもいいかなぁという気持ち...！
これって誰かがページにアクセスしないと動かないから、結局スリープ入るような気もするがどうなのか

こちらのコードを削除し、代わりにheroku schedulerを使うことで定期的にherokuサーバーを叩き、スリープを防ぐことにした。
![image](https://github.com/user-attachments/assets/c2466dfb-62fb-484a-9f0c-193884664351)

参考：
https://devcenter.heroku.com/ja/articles/scheduler
https://blog.enebular.com/samples/heroku-unsleep-free-dyno/

現状、herokuのプランはEco dynoプランで、これは5ドルで月にアカウント合計1000時間までサーバを動かせる。1月は720時間なので、1つのサーバだけを運用するならばずっとサーバを動かし続けていても大丈夫。
https://devcenter.heroku.com/ja/articles/eco-dyno-hours