### PR TITLE
react-selectのアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-icons": "^5.2.1",
         "react-katex": "^3.0.1",
         "react-modal": "^3.16.1",
-        "react-select": "^5.7.4",
+        "react-select": "^5.8.0",
         "swr": "^2.2.5",
         "wiremock-captain": "^3.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-icons": "^5.2.1",
     "react-katex": "^3.0.1",
     "react-modal": "^3.16.1",
-    "react-select": "^5.7.4",
+    "react-select": "^5.8.0",
     "swr": "^2.2.5",
     "wiremock-captain": "^3.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4637,7 +4637,7 @@ react-select-event@^5.5.1:
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@^5.7.4:
+react-select@^5.8.0:
   version "5.8.0"
   resolved "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz"
   integrity sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==


### PR DESCRIPTION
こちらのレビュー指摘の修正。
https://bootcamp.fjord.jp/products/20784#comment_175374
> dev 環境だと console に Warning: Extra attributes from the server: aria-activedescendant みたいなのが表示されてそう
react-select 所以っぽく、もしかしたら https://github.com/JedWatson/react-select/blob/master/packages/react-select/CHANGELOG.md#580 にあげると解決するかも？

react-selectをアップデートした。